### PR TITLE
Fix threading issues by dedicated queues

### DIFF
--- a/doc/31-Changelog.md
+++ b/doc/31-Changelog.md
@@ -17,6 +17,7 @@ Released closed milestones can be found on [GitHub](https://github.com/Icinga/ic
 
 ## Bugfixes
 
+* [#3](https://github.com/Icinga/icinga-powershell-restapi/issues/3) Fixes threading queueing issue for incoming API requests
 * [#5](https://github.com/Icinga/icinga-powershell-restapi/pull/5) Fixes memory leak on REST-Api and now forces error and memory cleanup
 
 ## 1.1.0 (2021-03-02)

--- a/lib/threads/Start-IcingaWindowsRESTThread.psm1
+++ b/lib/threads/Start-IcingaWindowsRESTThread.psm1
@@ -20,20 +20,22 @@ function Start-IcingaWindowsRESTThread()
         while ($TRUE) {
 
             try {
-                if ($IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests.Count -eq 0) {
+                if ($IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests.ContainsKey($ThreadId) -eq $FALSE) {
                     Start-Sleep -Milliseconds 10;
                     continue;
                 }
 
-                $ApiCallObject = Pop-IcingaArrayListItem -Array $IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests;
-
-                if ($ApiCallObject.ThreadId -ne $ThreadId) {
-                    Add-IcingaArrayListItem -Array $IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests -Element $ApiCallObject;
-                    Start-Sleep -Milliseconds 100;
+                if ($IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests.$ThreadId.Count -eq 0) {
+                    Start-Sleep -Milliseconds 10;
                     continue;
                 }
+    
+                $Connection = $IcingaDaemonData.IcingaThreadContent.RESTApi.ApiRequests.$ThreadId.Dequeue();
 
-                $Connection = $ApiCallObject.Connection;
+                if ($null -eq $Connection) {
+                    Start-Sleep -Milliseconds 10;
+                    continue;
+                }
 
                 # Read the received message from the stream by using our smart functions
                 [string]$RestMessage = Read-IcingaTCPStream -Client $Connection.Client -Stream $Connection.Stream;


### PR DESCRIPTION
The former code had one common `ArrayList` where all worker threads tried to pull their work from. That's a bit problematic:
- A thread took a connection from the list, decided if it was the recipient, and if not, added it back to the list, so that an arbitrary other thread can pick it up. In theory a connection can be taken by wrong threads again and again until forever.
- The `ArrayList` was not wrapped in Synchronized(). Multiple threads add and remove from it concurrently, that's racy.

This PR gives every worker thread dedicated and synchronized channel to the main thread. This makes the "am I the recipient?" logic unnecessary and is in general simpler to maintain.

Also, connections accepted earlier should also be handled earlier. Sounds like FIFO, so use a Queue instead of a List.

Fixes #3. After this change the timeouts no longer happen.